### PR TITLE
security: add least-privilege permissions to import workflows

### DIFF
--- a/.github/workflows/import_cambridge_events.yml
+++ b/.github/workflows/import_cambridge_events.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - 'apify_integration_cambridge'
+permissions: {}
+
 jobs:
   build:
     name: Import City of Cambridge events

--- a/.github/workflows/import_eventbrite_events.yml
+++ b/.github/workflows/import_eventbrite_events.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - 'eventbrite_integration'
+permissions: {}
+
 jobs:
   build:
     name: Import Eventbrite events

--- a/.github/workflows/import_explore_waterloo_events.yml
+++ b/.github/workflows/import_explore_waterloo_events.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - 'explore_integration'
+permissions: {}
+
 jobs:
   build:
     name: Import Explore Waterloo events

--- a/.github/workflows/import_kitchener_events.yml
+++ b/.github/workflows/import_kitchener_events.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - 'apify_integration_kitchener'
+permissions: {}
+
 jobs:
   build:
     name: Import City of Kitchener events

--- a/.github/workflows/import_museums_events.yml
+++ b/.github/workflows/import_museums_events.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - 'apify_integration_museums'
+permissions: {}
+
 jobs:
   build:
     name: Import RoW museums events

--- a/.github/workflows/import_waterloo_events.yml
+++ b/.github/workflows/import_waterloo_events.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - 'waterloo_integration'
+permissions: {}
+
 jobs:
   build:
     name: Import City of Waterloo events

--- a/.github/workflows/import_wpl_events.yml
+++ b/.github/workflows/import_wpl_events.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - 'wpl_integration'
+permissions: {}
+
 jobs:
   build:
     name: Import WPL events


### PR DESCRIPTION
## Summary

GitHub code scanning flagged that all 7 import event workflows were missing explicit `permissions` blocks (alerts #1–7).

These workflows only make a single `curl` POST request to an external API endpoint — they never touch the repository, run checkout, or call any GitHub API. So the correct permissions are `permissions: {}` — zero token access.

**Affected workflows:**
- `import_cambridge_events.yml`
- `import_eventbrite_events.yml`
- `import_explore_waterloo_events.yml`
- `import_kitchener_events.yml`
- `import_museums_events.yml`
- `import_waterloo_events.yml`
- `import_wpl_events.yml`

## What this changes

Nothing functional — the imports run identically. This just ensures the `GITHUB_TOKEN` is not provisioned at all for these jobs, so a compromised step couldn't interact with the repo or GitHub API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)