### PR TITLE
security: fix SSRF and URL validation in event importer

### DIFF
--- a/integrations/openai.js
+++ b/integrations/openai.js
@@ -36,25 +36,25 @@ function isValidPublicUrl(url) {
 function getExtractor(url) {
   try {
     const { hostname } = new URL(url);
-    if (hostname.endsWith('eventbrite.com') || hostname.endsWith('eventbrite.ca')) {
+    if (hostname === 'eventbrite.com' || hostname.endsWith('.eventbrite.com') || hostname === 'eventbrite.ca' || hostname.endsWith('.eventbrite.ca')) {
       return eventbriteExtractor;
     }
-    if (hostname.endsWith('meetup.com')) {
+    if (hostname === 'meetup.com' || hostname.endsWith('.meetup.com')) {
       return meetupExtractor;
     }
-    if (hostname.endsWith('explorewaterloo.ca')) {
+    if (hostname === 'explorewaterloo.ca' || hostname.endsWith('.explorewaterloo.ca')) {
       return exploreWaterlooExtractor;
     }
-    if (hostname.endsWith('calendar.waterlooregionmuseum.ca')) {
+    if (hostname === 'calendar.waterlooregionmuseum.ca') {
       return waterlooRegionMuseumExtractor;
     }
-    if (hostname.endsWith('calendar.kitchener.ca')) {
+    if (hostname === 'calendar.kitchener.ca') {
       return cityOfKitchenerExtractor;
     }
-    if (hostname.endsWith('events.cambridge.ca')) {
+    if (hostname === 'events.cambridge.ca') {
       return cityOfCambridgeExtractor;
     }
-    if (hostname.endsWith('events.waterloo.ca')) {
+    if (hostname === 'events.waterloo.ca') {
       return cityOfWaterlooExtractor;
     }
   } catch {
@@ -74,8 +74,8 @@ export const importEventFromUrl = async (url) => {
     }
 
     try { const { hostname } = new URL(url);
-      if (hostname.endsWith('facebook.com')) return { error: 'Facebook events are not supported, please use the event form.' };
-      if (hostname.endsWith('instagram.com')) return { error: 'Instagram posts are not supported, please use the event form.' };
+      if (hostname === 'facebook.com' || hostname.endsWith('.facebook.com')) return { error: 'Facebook events are not supported, please use the event form.' };
+      if (hostname === 'instagram.com' || hostname.endsWith('.instagram.com')) return { error: 'Instagram posts are not supported, please use the event form.' };
     } catch { return { error: 'Invalid URL.' }; }
 
     // Fetch the webpage content

--- a/integrations/openai.js
+++ b/integrations/openai.js
@@ -21,27 +21,44 @@ const openai = new OpenAI({
     apiKey: process.env.OPENAI_API_KEY,
 });
 
+function isValidPublicUrl(url) {
+  try {
+    const { protocol, hostname } = new URL(url);
+    if (!['http:', 'https:'].includes(protocol)) return false;
+    if (/^(localhost|127\.0\.0\.1|::1|0\.0\.0\.0)$/.test(hostname)) return false;
+    if (/^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|169\.254\.)/.test(hostname)) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function getExtractor(url) {
-  if (url.includes('eventbrite.com') || url.includes('eventbrite.ca')) {
-    return eventbriteExtractor;
-  }
-  if (url.includes('meetup.com')) {
-    return meetupExtractor;
-  }
-  if (url.includes('explorewaterloo.ca')) {
-    return exploreWaterlooExtractor;
-  }
-  if (url.includes('calendar.waterlooregionmuseum.ca')) {
-    return waterlooRegionMuseumExtractor;
-  }
-  if (url.includes('calendar.kitchener.ca')) {
-    return cityOfKitchenerExtractor;
-  }
-  if (url.includes('events.cambridge.ca')) {
-    return cityOfCambridgeExtractor;
-  }
-  if (url.includes('events.waterloo.ca')) {
-    return cityOfWaterlooExtractor;
+  try {
+    const { hostname } = new URL(url);
+    if (hostname.endsWith('eventbrite.com') || hostname.endsWith('eventbrite.ca')) {
+      return eventbriteExtractor;
+    }
+    if (hostname.endsWith('meetup.com')) {
+      return meetupExtractor;
+    }
+    if (hostname.endsWith('explorewaterloo.ca')) {
+      return exploreWaterlooExtractor;
+    }
+    if (hostname.endsWith('calendar.waterlooregionmuseum.ca')) {
+      return waterlooRegionMuseumExtractor;
+    }
+    if (hostname.endsWith('calendar.kitchener.ca')) {
+      return cityOfKitchenerExtractor;
+    }
+    if (hostname.endsWith('events.cambridge.ca')) {
+      return cityOfCambridgeExtractor;
+    }
+    if (hostname.endsWith('events.waterloo.ca')) {
+      return cityOfWaterlooExtractor;
+    }
+  } catch {
+    return null;
   }
   return null;
 }
@@ -52,13 +69,14 @@ export const importEventFromUrl = async (url) => {
       return { error: 'URL is required' };
     }
 
-    if (url.includes('facebook.com/events')) {
-      return { error: 'Facebook events are not supported, please use the event form.' };
+    if (!isValidPublicUrl(url)) {
+      return { error: 'Invalid or unsupported URL.' };
     }
 
-    if (url.includes('instagram.com/')) {
-      return { error: 'Instagram posts are not supported, please use the event form.' };
-    }
+    try { const { hostname } = new URL(url);
+      if (hostname.endsWith('facebook.com')) return { error: 'Facebook events are not supported, please use the event form.' };
+      if (hostname.endsWith('instagram.com')) return { error: 'Instagram posts are not supported, please use the event form.' };
+    } catch { return { error: 'Invalid URL.' }; }
 
     // Fetch the webpage content
     const response = await fetch(url);


### PR DESCRIPTION
## Summary

CodeQL flagged a server-side request forgery (SSRF) vulnerability and incomplete URL sanitization in `integrations/openai.js` (alerts #17–20).

### The problem

`importEventFromUrl` accepted any user-supplied URL and passed it directly to `fetch()`. The domain checks only selected which extractor to use — they didn't gate the actual HTTP request. An attacker could pass:
- `http://169.254.169.254/` (cloud metadata endpoint)
- `http://localhost/admin`
- `http://192.168.1.1/` (internal network)

Additionally, `url.includes('eventbrite.com')` can be bypassed with a URL like `https://evil.com/path?redirect=eventbrite.com`.

### The fix

**`isValidPublicUrl()`** — validates before `fetch()`:
- Must be `http:` or `https:`
- Blocks `localhost`, `127.0.0.1`, `::1`
- Blocks RFC-1918 private ranges (`10.x`, `172.16-31.x`, `192.168.x`, `169.254.x`)

**`getExtractor()`** — now uses `new URL(hostname).endsWith()` instead of `url.includes()`, so the domain check can't be bypassed by crafting the path or query string.

### What's dismissed (not in this PR)

- Alerts #9–16: XSS in `OMN_normalize_data.html` — minified third-party vendor code, not editable source
- Alert #8: XSS in `EventForm.js` — `<img src>` in a React component; React escapes attribute values, this cannot execute JS

🤖 Generated with [Claude Code](https://claude.com/claude-code)