### PR TITLE
ci: group Dependabot security updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds a `dependabot.yml` configuration that groups all security updates into a single PR per ecosystem, rather than one PR per package.

**Ecosystems configured:** `npm`, `github-actions`

Without grouping, Dependabot opens one PR per vulnerable package — this repo could see many PRs at once as security scanning ramps up. Grouping batches them into one weekly PR that's easier to review and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
